### PR TITLE
add CoreELEC-Settings - like LibreELEC-Settings

### DIFF
--- a/xml/Settings.xml
+++ b/xml/Settings.xml
@@ -120,7 +120,7 @@
                         <label>CoreELEC</label>
                         <onclick>RunAddon(service.coreelec.settings)</onclick>
                         <icon>icons/settings/libreelec.png</icon>
-                        <visible>System.HasAddon(service.Coreelec.settings)</visible>
+                        <visible>System.HasAddon(service.coreelec.settings)</visible>
                     </item>
                     <item>
                         <label>$LOCALIZE[13200]</label>

--- a/xml/Settings.xml
+++ b/xml/Settings.xml
@@ -117,6 +117,12 @@
                         <visible>System.HasAddon(service.libreelec.settings)</visible>
                     </item>
                     <item>
+                        <label>CoreELEC</label>
+                        <onclick>RunAddon(service.coreelec.settings)</onclick>
+                        <icon>icons/settings/libreelec.png</icon>
+                        <visible>System.HasAddon(service.Coreelec.settings)</visible>
+                    </item>
+                    <item>
                         <label>$LOCALIZE[13200]</label>
                         <onclick>ActivateWindow(Profiles)</onclick>
                         <icon>icons/settings/profiles.png</icon>


### PR DESCRIPTION
wie oben beschrieben:
Bei CoreELEC wird in den Settings kein Link zu den CoreELEC-Einstellungen angezeigt.